### PR TITLE
Replace object argument with simpler string in session management functions

### DIFF
--- a/src/models/otrStore.js
+++ b/src/models/otrStore.js
@@ -29,7 +29,8 @@ OtrStore.prototype.initChan = function(args) {
 
 	if (chan.type === Chan.Type.QUERY) {
 		var network = _.find(this.client.networks, {id: network_id});
-		var session = this.getSession(chan.name, network);
+		var host = network.host;
+		var session = this.getSession(chan.name, host);
 		var irc = network.irc;
 		if (session === undefined) {
 			session = new OTR({
@@ -84,18 +85,18 @@ OtrStore.prototype.initChan = function(args) {
 				// AKE_INIT ? Still have to figure out.
 			});
 
-			this.registerSession(chan.name, network, session);
+			this.registerSession(chan.name, host, session);
 		}
 	}
 };
 
-OtrStore.prototype.getSession = function(nick, network) {
-	var qualifiedUser = nick + '@' + network.host;
+OtrStore.prototype.getSession = function(nick, host) {
+	var qualifiedUser = nick + '@' + host;
 	return this.sessions[qualifiedUser];
 };
 
-OtrStore.prototype.registerSession = function(nick, network, session) {
-	var qualifiedUser = nick + '@' + network.host;
+OtrStore.prototype.registerSession = function(nick, host, session) {
+	var qualifiedUser = nick + '@' + host;
 	this.sessions[qualifiedUser] = session;
 };
 

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -20,7 +20,7 @@ module.exports = function(network, chan, cmd, args) {
 		target = chan.name;
 	}
 	var msg = args.join(" ");
-	var otrSession = client.otrStore.getSession(chan.name, network);
+	var otrSession = client.otrStore.getSession(chan.name, network.host);
 	if (otrSession && (otrSession.msgstate === OTR.CONST.MSGSTATE_ENCRYPTED)) {
 		otrSession.sendMsg(msg);
 	} else {

--- a/src/plugins/inputs/otr.js
+++ b/src/plugins/inputs/otr.js
@@ -8,7 +8,7 @@ module.exports = function(network, chan, cmd, args) {
 	var subCmd = args[0];
 	var client = this;
 	var otrStore = client.otrStore;
-	var session = otrStore.getSession(chan.name, network);
+	var session = otrStore.getSession(chan.name, network.host);
 
 	if (subCmd === "init") {
 		session.sendQueryMsg();

--- a/src/plugins/irc-events/otrmessage.js
+++ b/src/plugins/irc-events/otrmessage.js
@@ -11,7 +11,7 @@ module.exports = function(irc, network) {
 
 		var otrSession = client.otrStore.getSession(
 			network.getMessageChanName(data),
-			network
+			network.host
 		);
 		otrSession.receiveMsg(data.message);
 	});


### PR DESCRIPTION
To my knowledge, I don't think we should expose the complex `network` object if there is no good reason too (also, we'll be happier if we want to unit test these ^^). Do you confirm?

~~If you are OK with this change, that will impact #8. Let's merge #8 first and I'll rebase this current PR to include the changes.~~ Done.
